### PR TITLE
content: convert llm kv cache post to mdx callouts

### DIFF
--- a/src/content/blog/2025/llm-kv-cache/index.md
+++ b/src/content/blog/2025/llm-kv-cache/index.md
@@ -80,7 +80,7 @@ $$
 $$
 \begin{align}
 X_{n+1} = \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         X_{n} \\
         x_{n+1} \\
     \end{array}
@@ -199,19 +199,19 @@ Y_{n+1}
 &= \text{softmax} \left( \text{Mask} \left(
 \frac{1}{\sqrt{d_k}}
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         Q_{n} \\
         q_{n+1} \\
     \end{array}
 \right ]
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         K_{n} \\
         k_{n+1} \\
     \end{array}
 \right ]^{\top} \right) \right)
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         V_{n} \\
         v_{n+1} \\
     \end{array}
@@ -219,18 +219,19 @@ Y_{n+1}
 &= \text{softmax} \left( \text{Mask} \left(
 \frac{1}{\sqrt{d_k}}
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         Q_{n} \\
         q_{n+1} \\
     \end{array}
 \right ]
 \left [
-    \begin{array}{c|c}
-        K_{n}^{\top} & k_{n+1}^{\top} \\
+    \begin{array}{c}
+        K_{n}^{\top} \\
+        k_{n+1}^{\top} \\
     \end{array}
 \right ] \right) \right)
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         V_{n} \\
         v_{n+1} \\
     \end{array}
@@ -246,7 +247,7 @@ Y_{n+1}
 \right ]
 \right) \right)
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         V_{n} \\
         v_{n+1} \\
     \end{array}
@@ -261,14 +262,14 @@ Y_{n+1}
 \right ]
 \right)
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         V_{n} \\
         v_{n+1} \\
     \end{array}
 \right ] \\
 &=
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
     \left [
         \begin{array}{c|c}
             \text{softmax} \left(\text{Mask} \left( \frac{1}{\sqrt{d_k}} Q_{n}K_{n}^{\top}\right) \right) & 0 \\
@@ -287,14 +288,14 @@ Y_{n+1}
     \end{array}
 \right ]
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         V_{n} \\
         v_{n+1} \\
     \end{array}
 \right ] \\
 &=
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
         \text{softmax} \left(\text{Mask} \left( \frac{1}{\sqrt{d_k}} Q_{n}K_{n}^{\top}\right) \right) V_{n} \\
     \hline
     \text{softmax}
@@ -305,7 +306,7 @@ Y_{n+1}
 \right ] \\
 &=
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
     Y_{n} \\
     \text{softmax}
     \left(
@@ -315,7 +316,7 @@ Y_{n+1}
 \right ] \\
 &=
 \left [
-    \begin{array}{c|c}
+    \begin{array}{c}
     Y_{n} \\
     y_{n+1} \\
     \end{array}

--- a/src/content/blog/2025/llm-kv-cache/index.mdx
+++ b/src/content/blog/2025/llm-kv-cache/index.mdx
@@ -8,13 +8,14 @@ draft: false
 featured: true
 ---
 
+import Callout from '@/components/Callout.astro'
+
 ## Introduction
 
 在看很多大语言模型的推理代码时，发现有一个非常重要的概念，就是 KV Cache。
 这里我们简要介绍一下 KV Cache 的核心原理并给出基于 GPT-2 的代码实现以便于本地复现。
 相关的实验和测试代码同样开源在[toyllm](https://github.com/ai-glimpse/toyllm).
 
-<!-- more -->
 
 ## What
 
@@ -486,25 +487,23 @@ class KVCache(nn.Module):
 
 ```
 
-> **Note: 如果你对这里的`register_buffer`有疑惑**
->
->
-> 简单来说，`register_buffer`可以使得我们在模型中注册一个持久化的 buffer，这个 buffer 不会被视为模型的参数 (自然也不会更新)。
-> 这里存在一个问题，那就是为什么要用`register_buffer`而不是直接用`self.k_cache = ...`呢？
-> 答案很简单，通过`register_buffer`注册的 buffer 可以随着`model.to(device)`的调用而自动转移到指定的设备上，而后一种方式则不会。
->
-> >In essence, PyTorch buffers are tensor attributes associated with a PyTorch module or model similar to parameters,
-> >but unlike parameters, buffers are not updated during training.
->
-> >Buffers in PyTorch are particularly useful when dealing with GPU computations, as they need to be transferred
-> >between devices (like from CPU to GPU) alongside the model's parameters. Unlike parameters, buffers do not require gradient computation, but they still need to be on the correct device to ensure that all computations are performed correctly.
->
-> 更多的细节可以参考以下链接：
->
-> - [PyTorch register_buffer](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_buffer)
->
-> - [LLMs-from-scratch explain](https://github.com/rasbt/LLMs-from-scratch/blob/main/ch03/03_understanding-buffers/understanding-buffers.ipynb)
->
+<Callout variant="note" title="如果你对这里的 `register_buffer` 有疑惑">
+简单来说，`register_buffer` 可以使得我们在模型中注册一个持久化的 buffer，这个 buffer 不会被视为模型的参数，自然也不会更新。
+这里存在一个问题，那就是为什么要用 `register_buffer` 而不是直接用 `self.k_cache = ...` 呢？
+答案很简单，通过 `register_buffer` 注册的 buffer 可以随着 `model.to(device)` 的调用而自动转移到指定的设备上，而后一种方式则不会。
+
+> In essence, PyTorch buffers are tensor attributes associated with a PyTorch module or model similar to parameters,
+> but unlike parameters, buffers are not updated during training.
+
+> Buffers in PyTorch are particularly useful when dealing with GPU computations, as they need to be transferred
+> between devices (like from CPU to GPU) alongside the model's parameters. Unlike parameters, buffers do not require gradient computation, but they still need to be on the correct device to ensure that all computations are performed correctly.
+
+更多的细节可以参考以下链接：
+
+- [PyTorch register_buffer](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_buffer)
+- [LLMs-from-scratch explain](https://github.com/rasbt/LLMs-from-scratch/blob/main/ch03/03_understanding-buffers/understanding-buffers.ipynb)
+</Callout>
+
 注意这里`KVCache`内部`cache`的维度：`cache_shape = (batch_size, num_kv_heads, max_seq_len, head_dim)`.
 其中，`batch_size`是模型的 batch size，`num_kv_heads`是模型的 kv head 的数量，`max_seq_len`是模型的最大序列长度，`head_dim`是每个 kv head 的维度。
 也就是说，这里会缓存**batch 中每个样本的每个 kv head 在每个位置上的 key 和 value(两者均为维度等于`head_dim`的向量)**。
@@ -520,14 +519,12 @@ self.cache_pos += seq_len
 
 这里的`self.cache_pos`表示当前缓存的最后一个位置，`seq_len`表示当前输入的序列长度。
 
-> **Note: 和 torchtune 实现的些许差别**
->
->
-> 如果你之前看过 torchtune 的 KV Cache 实现，那么你会发现这里 KV Cache 的实现和 torchtune 基本是一样的——除了`cache_pos`的实现。
-> 在 torchtune 最早的实现中`cache_pos`就是上面的这种形式，不过后续为了兼容`torch.compile`将其实现为一个向量而不是一个整数。
-> 具体参考对应 issue: [#2564](https://github.com/pytorch/torchtune/issues/2564), [#1663](https://github.com/pytorch/torchtune/issues/1663).
->
->
+<Callout variant="note" title="和 torchtune 实现的些许差别">
+如果你之前看过 torchtune 的 KV Cache 实现，那么你会发现这里 KV Cache 的实现和 torchtune 基本是一样的，除了 `cache_pos` 的实现。
+在 torchtune 最早的实现中，`cache_pos` 就是上面的这种形式，不过后续为了兼容 `torch.compile` 将其实现为一个向量而不是一个整数。
+具体参考对应 issue: [#2564](https://github.com/pytorch/torchtune/issues/2564), [#1663](https://github.com/pytorch/torchtune/issues/1663).
+</Callout>
+
 ## The end
 
 KV Cache 作为一项核心的 LLM 推理优化技术，已经在很多框架中应用，相关优化也在持续进行中。本文难以详尽介绍，故仅从其原始形态管窥一二。


### PR DESCRIPTION
## Changes
- convert the LLM KV Cache post from Markdown to MDX
- replace Note blockquotes with the existing Callout component
- keep the post content aligned with the site's MDX content patterns

## Validation
- pnpm astro check