### PR TITLE
feat: make tags clickable with hover effects

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -1,6 +1,6 @@
 ---
+import TagBadge from '@/components/TagBadge.astro'
 import AvatarComponent from '@/components/ui/avatar'
-import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import {
   getCombinedReadingTime,
@@ -9,8 +9,7 @@ import {
   parseAuthors,
 } from '@/lib/data-utils'
 import { getDisplayCoverImage } from '@/lib/post-images'
-import { cn } from '@/lib/utils'
-import { formatDate } from '@/lib/utils'
+import { cn, formatDate } from '@/lib/utils'
 import { Icon } from 'astro-icon/components'
 import { Image } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
@@ -31,17 +30,24 @@ const coverImage = getDisplayCoverImage(entry)
 
 <div
   class={cn(
-    'hover:bg-muted/50 rounded-xl border transition-colors duration-300 ease-in-out',
+    'hover:bg-muted/50 relative rounded-xl border transition-colors duration-300 ease-in-out',
     compact ? 'p-3' : 'p-4',
   )}
 >
-  <Link
-    href={`/${entry.collection}/${entry.id}`}
-    class="flex flex-col gap-4 sm:flex-row sm:items-start"
-  >
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-start">
     <div class="grow">
-      <h3 class={cn('font-medium', compact ? 'mb-0.5 text-base leading-snug' : 'mb-1 text-lg')}>
-        {entry.data.title}
+      <h3
+        class={cn(
+          'font-medium',
+          compact ? 'mb-0.5 text-base leading-snug' : 'mb-1 text-lg',
+        )}
+      >
+        <Link
+          href={`/${entry.collection}/${entry.id}`}
+          class="before:absolute before:inset-0 before:z-0 before:content-['']"
+        >
+          {entry.data.title}
+        </Link>
       </h3>
       <p
         class={cn(
@@ -62,28 +68,44 @@ const coverImage = getDisplayCoverImage(entry)
           authors.length > 0 && (
             <>
               {authors.map((author) => (
-                <div class={cn('flex items-center', compact ? 'gap-x-1' : 'gap-x-1.5')}>
+                <div
+                  class={cn(
+                    'flex items-center',
+                    compact ? 'gap-x-1' : 'gap-x-1.5',
+                  )}
+                >
                   <AvatarComponent
                     client:load
                     src={author.avatar}
                     alt={author.name}
                     fallback={author.name[0]}
-                    className={compact ? 'size-4 rounded-full' : 'size-5 rounded-full'}
+                    className={
+                      compact ? 'size-4 rounded-full' : 'size-5 rounded-full'
+                    }
                   />
                   <span>{author.name}</span>
                 </div>
               ))}
-              <Separator orientation="vertical" className={compact ? 'h-3!' : 'h-4!'} />
+              <Separator
+                orientation="vertical"
+                className={compact ? 'h-3!' : 'h-4!'}
+              />
             </>
           )
         }
         <span>{formattedDate}</span>
-        <Separator orientation="vertical" className={compact ? 'h-3!' : 'h-4!'} />
+        <Separator
+          orientation="vertical"
+          className={compact ? 'h-3!' : 'h-4!'}
+        />
         <span>{readTime}</span>
         {
           subpostCount > 0 && (
             <>
-              <Separator orientation="vertical" className={compact ? 'h-3!' : 'h-4!'} />
+              <Separator
+                orientation="vertical"
+                className={compact ? 'h-3!' : 'h-4!'}
+              />
               <span class="flex items-center gap-1">
                 <Icon name="lucide:file-text" class="size-3" />
                 {subpostCount} subpost{subpostCount === 1 ? '' : 's'}
@@ -95,18 +117,14 @@ const coverImage = getDisplayCoverImage(entry)
 
       {
         entry.data.tags && (
-          <div class={cn('flex flex-wrap', compact ? 'gap-1.5' : 'gap-2')}>
+          <div
+            class={cn(
+              'relative z-10 flex flex-wrap',
+              compact ? 'gap-1.5' : 'gap-2',
+            )}
+          >
             {entry.data.tags.map((tag) => (
-              <Badge
-                variant="muted"
-                className={cn(
-                  'flex items-center gap-x-1',
-                  compact && 'px-1.5 py-0 text-[11px] leading-5',
-                )}
-              >
-                <Icon name="lucide:hash" class="size-3" />
-                {tag}
-              </Badge>
+              <TagBadge tag={tag} compact={compact} />
             ))}
           </div>
         )
@@ -128,5 +146,5 @@ const coverImage = getDisplayCoverImage(entry)
         </div>
       )
     }
-  </Link>
+  </div>
 </div>

--- a/src/components/TagBadge.astro
+++ b/src/components/TagBadge.astro
@@ -1,0 +1,25 @@
+---
+import { badgeVariants } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import { Icon } from 'astro-icon/components'
+
+interface Props {
+  tag: string
+  compact?: boolean
+}
+
+const { tag, compact = false } = Astro.props
+---
+
+<a
+  href={`/tags/${tag}`}
+  class={cn(
+    badgeVariants({ variant: 'muted' }),
+    'cursor-pointer transition-all duration-200',
+    'hover:bg-primary/10 hover:border-primary/30 hover:text-primary hover:scale-105 hover:shadow-sm',
+    compact && 'px-1.5 py-0 text-[11px] leading-5',
+  )}
+>
+  <Icon name="lucide:hash" class="size-3" />
+  {tag}
+</a>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -6,9 +6,9 @@ import PostHead from '@/components/PostHead.astro'
 import PostNavigation from '@/components/PostNavigation.astro'
 import SubpostsHeader from '@/components/SubpostsHeader.astro'
 import SubpostsSidebar from '@/components/SubpostsSidebar.astro'
+import TagBadge from '@/components/TagBadge.astro'
 import TOCHeader from '@/components/TOCHeader.astro'
 import TOCSidebar from '@/components/TOCSidebar.astro'
-import { badgeVariants } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Layout from '@/layouts/Layout.astro'
 import {
@@ -210,15 +210,7 @@ const coverImage = getDisplayCoverImage(post)
           {
             post.data.tags &&
               post.data.tags.length > 0 &&
-              post.data.tags.map((tag) => (
-                <a
-                  href={`/tags/${tag}`}
-                  class={badgeVariants({ variant: 'muted' })}
-                >
-                  <Icon name="lucide:hash" class="size-3" />
-                  {tag}
-                </a>
-              ))
+              post.data.tags.map((tag) => <TagBadge tag={tag} />)
           }
         </div>
       </div>
@@ -309,7 +301,8 @@ const coverImage = getDisplayCoverImage(post)
           while (node) {
             if (node.nodeType === Node.TEXT_NODE) {
               // 移除仅包含逗号/顿号/空格等分隔符的文本节点
-              const trimmed = node.textContent?.replace(/[\s,，、;；]+/g, '') ?? ''
+              const trimmed =
+                node.textContent?.replace(/[\s,，、;；]+/g, '') ?? ''
               if (trimmed === '') {
                 // 下一个有意义的元素是 sup 脚注时才移除
                 const nextEl = sup.nextElementSibling
@@ -328,29 +321,27 @@ const coverImage = getDisplayCoverImage(post)
         })
 
       // 脚注 tooltip：提取底部脚注内容，写入行内引用的 data-tooltip
-      document
-        .querySelectorAll('a[data-footnote-ref]')
-        .forEach((ref) => {
-          const href = ref.getAttribute('href')
-          if (!href) return
-          const targetId = href.replace('#', '')
-          const footnoteLi = document.getElementById(targetId)
-          if (!footnoteLi) return
+      document.querySelectorAll('a[data-footnote-ref]').forEach((ref) => {
+        const href = ref.getAttribute('href')
+        if (!href) return
+        const targetId = href.replace('#', '')
+        const footnoteLi = document.getElementById(targetId)
+        if (!footnoteLi) return
 
-          // 克隆节点，移除回退链接后取纯文本
-          const clone = footnoteLi.cloneNode(true) as HTMLElement
-          clone
-            .querySelectorAll('a[data-footnote-backref]')
-            .forEach((el) => el.remove())
-          const text = clone.textContent?.trim().replace(/\s+/g, ' ') ?? ''
-          if (text) {
-            // 限制 tooltip 长度，过长时截断
-            ref.setAttribute(
-              'data-tooltip',
-              text.length > 150 ? text.slice(0, 147) + '…' : text,
-            )
-          }
-        })
+        // 克隆节点，移除回退链接后取纯文本
+        const clone = footnoteLi.cloneNode(true) as HTMLElement
+        clone
+          .querySelectorAll('a[data-footnote-backref]')
+          .forEach((el) => el.remove())
+        const text = clone.textContent?.trim().replace(/\s+/g, ' ') ?? ''
+        if (text) {
+          // 限制 tooltip 长度，过长时截断
+          ref.setAttribute(
+            'data-tooltip',
+            text.length > 150 ? text.slice(0, 147) + '…' : text,
+          )
+        }
+      })
     })
   </script>
 </Layout>


### PR DESCRIPTION
## Summary
Make tags in blog cards and blog detail pages clickable, linking to their respective tag pages.

## Changes
- Create reusable `TagBadge` component for consistent tag styling and behavior
- Tags now link to `/tags/{tag}` page
- Add hover effects for better UX:
  - Background color changes to primary color (10% opacity)
  - Border color changes to primary color (30% opacity)
  - Text color changes to primary color
  - Slight scale up (105%)
  - Subtle shadow
  - Smooth 200ms transition

## Files Changed
- `src/components/TagBadge.astro` (new) - Reusable tag badge component
- `src/components/BlogCard.astro` - Use TagBadge component
- `src/pages/blog/[...id].astro` - Use TagBadge component