### PR TITLE
fix: improve chinese pagefind search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ pnpm prettier       # 格式化所有文件
 - `src/components/` - Astro/React 组件
 - `src/pages/` - 页面路由
 
+## 搜索说明
+
+- 搜索使用 Pagefind，索引语言为 `zh`。`NavSearch.astro` 和 `search.astro` 初始化 Pagefind 搜索实例时会短暂将 `<html lang>` 设为 `en`，这是为了绕开 Pagefind/浏览器 CJK 查询分词把“无双”等短词拆开的行为；该处理只影响查询解析，索引仍是中文 Pagefind 索引。
+
 ## 博客文章 Frontmatter
 
 ```yml

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     icon(),
     pagefind({
       indexConfig: {
-        forceLanguage: 'zh-cn',
+        forceLanguage: 'zh',
       },
     }),
   ],

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
       "yaml": "2.8.3",
       "@iconify/tools>svgo": "3.3.3",
       "@iconify/tools>tar": "7.5.11",
-      "cheerio>undici": "7.24.0"
+      "cheerio>undici": "7.24.0",
+      "pagefind": "1.5.2"
     }
   },
   "prettier": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   '@iconify/tools>svgo': 3.3.3
   '@iconify/tools>tar': 7.5.11
   cheerio>undici: 7.24.0
+  pagefind: 1.5.2
 
 importers:
 
@@ -900,41 +901,41 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@pagefind/darwin-arm64@1.5.0':
-    resolution: {integrity: sha512-OXQVlxALU9+Lz/LxkAa+RvaxY1cnRKUDCuwl9o8PY5Lg/znP573y4WIbVOOIz8Bv7uj7r00TGy7pD+NSLMJGBw==}
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pagefind/darwin-x64@1.5.0':
-    resolution: {integrity: sha512-+LK1Xq5n/B0hHc08DW61SnfIlfLKyXZ1oKcbfZ1MimE7Rn0Q6R0VI/TlC04f/JDPm+67zAOwPGizzvefOi5vqQ==}
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
     cpu: [x64]
     os: [darwin]
 
   '@pagefind/default-ui@1.5.0':
     resolution: {integrity: sha512-C8VZ5pDz1Kc89GicXsWZiIlAwTVwUtFDOzh0RzJt5FmbkJzsmPVICPkLUfOsWgBCyFAH/vYR+lUTaGPDxZ4IXw==}
 
-  '@pagefind/freebsd-x64@1.5.0':
-    resolution: {integrity: sha512-kicDfUF9gn/z06NimTwNlZXF8z3pLsN3BIPPt6N8unuh0n55fr64tVs2p3a5RKYmQkJGjPfOE/C9GI5YTEpURg==}
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@pagefind/linux-arm64@1.5.0':
-    resolution: {integrity: sha512-e5rDB3wPm89bcSLiatKBDTrVTbsMQrrtkXRaAoUJYU0C1suXVvEzZfjmMvrUDvYhZBx/Ls8hGuGxlqSJBz3gDg==}
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
     cpu: [arm64]
     os: [linux]
 
-  '@pagefind/linux-x64@1.5.0':
-    resolution: {integrity: sha512-vh52DcBiF/mRMmq+Rwt3M3RgEWgl00jFk/M5NWhLEHJFq4+papQXwbyKbi7cNlxaeYrKx6wOfW3fm9cftfc/Kg==}
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
     cpu: [x64]
     os: [linux]
 
-  '@pagefind/windows-arm64@1.5.0':
-    resolution: {integrity: sha512-kg+szZwffZdyWn6SL6RHjAYjhSvJ2bT4qkv3KepGsbmD9fuSHUSC+2kydDneDVUA9qEDRf9uSFoEAsXsp1/JKA==}
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
     cpu: [arm64]
     os: [win32]
 
-  '@pagefind/windows-x64@1.5.0':
-    resolution: {integrity: sha512-8eOCmB8lnpyvwz+HrcTXLuBxhj7UseAFh6KGEXRe8UCcAfVQih+qPy/4akJRezViI+ONijz9oi7HpMkw9rdtBg==}
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
 
@@ -3079,8 +3080,8 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
-  pagefind@1.5.0:
-    resolution: {integrity: sha512-7vQ2xh0ZmjPjsuWONR68nqzb+QNfpPh7pdT6n6YDAthWAQiUkSACVegSswY5zPNONGYFWebFVgdnS5/m/Qqn+w==}
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
     hasBin: true
 
   parse-entities@4.0.2:
@@ -4780,27 +4781,27 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@pagefind/darwin-arm64@1.5.0':
+  '@pagefind/darwin-arm64@1.5.2':
     optional: true
 
-  '@pagefind/darwin-x64@1.5.0':
+  '@pagefind/darwin-x64@1.5.2':
     optional: true
 
   '@pagefind/default-ui@1.5.0': {}
 
-  '@pagefind/freebsd-x64@1.5.0':
+  '@pagefind/freebsd-x64@1.5.2':
     optional: true
 
-  '@pagefind/linux-arm64@1.5.0':
+  '@pagefind/linux-arm64@1.5.2':
     optional: true
 
-  '@pagefind/linux-x64@1.5.0':
+  '@pagefind/linux-x64@1.5.2':
     optional: true
 
-  '@pagefind/windows-arm64@1.5.0':
+  '@pagefind/windows-arm64@1.5.2':
     optional: true
 
-  '@pagefind/windows-x64@1.5.0':
+  '@pagefind/windows-x64@1.5.2':
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
@@ -5983,7 +5984,7 @@ snapshots:
     dependencies:
       '@pagefind/default-ui': 1.5.0
       astro: 6.1.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.3)
-      pagefind: 1.5.0
+      pagefind: 1.5.2
       sirv: 3.0.2
 
   astro@6.1.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.3):
@@ -7430,15 +7431,15 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pagefind@1.5.0:
+  pagefind@1.5.2:
     optionalDependencies:
-      '@pagefind/darwin-arm64': 1.5.0
-      '@pagefind/darwin-x64': 1.5.0
-      '@pagefind/freebsd-x64': 1.5.0
-      '@pagefind/linux-arm64': 1.5.0
-      '@pagefind/linux-x64': 1.5.0
-      '@pagefind/windows-arm64': 1.5.0
-      '@pagefind/windows-x64': 1.5.0
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
 
   parse-entities@4.0.2:
     dependencies:

--- a/src/components/NavSearch.astro
+++ b/src/components/NavSearch.astro
@@ -53,6 +53,11 @@ const baseUrl = import.meta.env.BASE_URL ?? '/'
 
 <script>
   type PagefindModule = {
+    createInstance?: () => PagefindSearchApi
+    search: PagefindSearchApi['search']
+  }
+  type PagefindSearchApi = {
+    init?: () => Promise<void>
     search: (query: string) => Promise<{
       results: Array<{ data: () => Promise<PagefindResult> }>
     }>
@@ -68,8 +73,8 @@ const baseUrl = import.meta.env.BASE_URL ?? '/'
   }
 
   // 全局缓存 pagefind 模块
-  let pagefind: PagefindModule | null = null
-  let pagefindPromise: Promise<PagefindModule> | null = null
+  let pagefind: PagefindSearchApi | null = null
+  let pagefindPromise: Promise<PagefindSearchApi> | null = null
 
   const initNavSearch = () => {
     const container = document.querySelector('[data-nav-search]')
@@ -108,6 +113,25 @@ const baseUrl = import.meta.env.BASE_URL ?? '/'
       }${path}`
     }
 
+    const createSearchInstance = async (module: PagefindModule) => {
+      if (!module.createInstance) return module
+
+      const html = document.documentElement
+      const originalLang = html.getAttribute('lang')
+      // Hack: Pagefind reads html lang to choose query segmentation; using "en"
+      // here avoids splitting short Chinese terms like "无双". The index remains zh.
+      html.setAttribute('lang', 'en')
+      const instance = module.createInstance()
+      if (originalLang) {
+        html.setAttribute('lang', originalLang)
+      } else {
+        html.removeAttribute('lang')
+      }
+      await instance.init?.()
+
+      return instance
+    }
+
     const loadPagefind = () => {
       if (pagefind) return Promise.resolve(pagefind)
       if (pagefindPromise) return pagefindPromise
@@ -117,8 +141,8 @@ const baseUrl = import.meta.env.BASE_URL ?? '/'
       const bundleUrl = `${normalizedBase.replace(/\/$/, '')}/pagefind/pagefind.js`
 
       pagefindPromise = import(/* @vite-ignore */ bundleUrl)
-        .then((module) => {
-          pagefind = module as PagefindModule
+        .then(async (module) => {
+          pagefind = await createSearchInstance(module as PagefindModule)
           return pagefind
         })
         .catch((error) => {

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from '@/layouts/Layout.astro'
-import PagefindSearch from 'astro-pagefind/components/Search'
 ---
 
 <Layout>
@@ -12,41 +11,259 @@ import PagefindSearch from 'astro-pagefind/components/Search'
       </p>
     </header>
 
-    <PagefindSearch
-      id="search"
-      className="pagefind-ui"
-      uiOptions={{ showImages: false }}
-    />
+    <div
+      class="flex flex-col gap-3"
+      data-pagefind-search
+      data-base-url={import.meta.env.BASE_URL ?? '/'}
+    >
+      <label class="sr-only" for="search-input">Search</label>
+      <input
+        id="search-input"
+        type="search"
+        autocomplete="off"
+        placeholder="Search"
+        class="border-input bg-background text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 h-10 rounded-md border px-3 text-sm outline-none focus-visible:ring-2"
+        data-search-input
+      />
+      <div
+        class="text-muted-foreground text-sm"
+        aria-live="polite"
+        data-search-summary
+      >
+        Type to search.
+      </div>
+      <div class="flex flex-col divide-y" data-search-results></div>
+    </div>
   </section>
 </Layout>
 
 <script>
-  const applyQuery = () => {
-    const params = new URLSearchParams(window.location.search)
-    const query = params.get('q')
-    if (!query) return
-
-    let attempts = 0
-    const timer = window.setInterval(() => {
-      const input = document.querySelector<HTMLInputElement>(
-        '.pagefind-ui__search-input',
-      )
-      if (input) {
-        input.value = query
-        input.dispatchEvent(new Event('input', { bubbles: true }))
-        window.clearInterval(timer)
-      }
-      attempts += 1
-      if (attempts >= 20) {
-        window.clearInterval(timer)
-      }
-    }, 100)
+  type PagefindResult = {
+    url: string
+    title?: string
+    excerpt?: string
+    meta?: {
+      title?: string
+      date?: string
+    }
+  }
+  type PagefindSearchApi = {
+    init?: () => Promise<void>
+    search: (query: string) => Promise<{
+      results: Array<{ data: () => Promise<PagefindResult> }>
+    }>
+  }
+  type PagefindModule = PagefindSearchApi & {
+    createInstance?: () => PagefindSearchApi
   }
 
-  document.addEventListener('astro:page-load', applyQuery)
+  let pagefind: PagefindSearchApi | null = null
+  let pagefindPromise: Promise<PagefindSearchApi> | null = null
+
+  const escapeHtml = (value: string) =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+
+  const highlightText = (value: string, query: string) => {
+    const terms = query
+      .split(/\s+/)
+      .map((term) => term.trim())
+      .filter(Boolean)
+    if (terms.length === 0) return escapeHtml(value)
+    const escapedTerms = terms.map((term) =>
+      term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    )
+    const regex = new RegExp(`(${escapedTerms.join('|')})`, 'gi')
+    return escapeHtml(value).replace(regex, '<mark>$1</mark>')
+  }
+
+  const createSearchInstance = async (module: PagefindModule) => {
+    if (!module.createInstance) return module
+
+    const html = document.documentElement
+    const originalLang = html.getAttribute('lang')
+    // Hack: Pagefind reads html lang to choose query segmentation; using "en"
+    // here avoids splitting short Chinese terms like "无双". The index remains zh.
+    html.setAttribute('lang', 'en')
+    const instance = module.createInstance()
+    if (originalLang) {
+      html.setAttribute('lang', originalLang)
+    } else {
+      html.removeAttribute('lang')
+    }
+    await instance.init?.()
+
+    return instance
+  }
+
+  const loadPagefind = (baseUrl: string) => {
+    if (pagefind) return Promise.resolve(pagefind)
+    if (pagefindPromise) return pagefindPromise
+
+    const bundleUrl = `${baseUrl.replace(/\/$/, '')}/pagefind/pagefind.js`
+    pagefindPromise = import(/* @vite-ignore */ bundleUrl)
+      .then(async (module) => {
+        pagefind = await createSearchInstance(module as PagefindModule)
+        return pagefind
+      })
+      .catch((error) => {
+        pagefindPromise = null
+        throw error
+      })
+
+    return pagefindPromise
+  }
+
+  const toUrl = (baseUrl: string, path: string) =>
+    `${baseUrl.replace(/\/$/, '')}${path.startsWith('/') ? '' : '/'}${path}`
+
+  const isPostPath = (baseUrl: string, url: string) => {
+    const absolute = new URL(toUrl(baseUrl, url), window.location.origin)
+    return /^\/blog\/\d{4}\//.test(absolute.pathname)
+  }
+
+  const formatDate = (value?: string) => {
+    if (!value) return ''
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return ''
+    return date.toLocaleDateString('zh-CN', {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+    })
+  }
+
+  const initSearch = () => {
+    const container = document.querySelector('[data-pagefind-search]')
+    if (!container || container.hasAttribute('data-initialized')) return
+    container.setAttribute('data-initialized', 'true')
+
+    const input = container.querySelector(
+      '[data-search-input]',
+    ) as HTMLInputElement | null
+    const summary = container.querySelector(
+      '[data-search-summary]',
+    ) as HTMLDivElement | null
+    const resultsEl = container.querySelector(
+      '[data-search-results]',
+    ) as HTMLDivElement | null
+    const baseUrl = container.getAttribute('data-base-url') || '/'
+    if (!(input && summary && resultsEl)) return
+
+    let timer: number | null = null
+    let activeQueryId = 0
+
+    const renderResults = (results: PagefindResult[], query: string) => {
+      resultsEl.innerHTML = ''
+      if (!query.trim()) {
+        summary.textContent = 'Type to search.'
+        return
+      }
+      if (results.length === 0) {
+        summary.textContent = 'No results found.'
+        return
+      }
+
+      summary.textContent = `${results.length} result${
+        results.length === 1 ? '' : 's'
+      }`
+      const fragment = document.createDocumentFragment()
+      for (const item of results) {
+        const link = document.createElement('a')
+        link.href = toUrl(baseUrl, item.url)
+        link.className =
+          'hover:bg-muted -mx-2 flex flex-col gap-2 rounded-md px-2 py-4 transition-colors'
+
+        const title = document.createElement('span')
+        title.className = 'text-foreground text-lg font-medium'
+        const titleText = item.meta?.title || item.title || 'Untitled'
+        title.innerHTML = highlightText(titleText, query)
+
+        const dateText = formatDate(item.meta?.date)
+        if (dateText) {
+          const meta = document.createElement('span')
+          meta.className = 'text-muted-foreground text-xs'
+          meta.textContent = dateText
+          link.append(title, meta)
+        } else {
+          link.append(title)
+        }
+
+        if (item.excerpt) {
+          const excerpt = document.createElement('span')
+          excerpt.className = 'text-muted-foreground text-sm leading-relaxed'
+          excerpt.innerHTML = item.excerpt
+          link.append(excerpt)
+        }
+
+        fragment.append(link)
+      }
+      resultsEl.append(fragment)
+    }
+
+    const search = async (query: string) => {
+      const trimmed = query.trim()
+      const queryId = (activeQueryId += 1)
+      if (!trimmed) {
+        renderResults([], '')
+        return
+      }
+
+      summary.textContent = 'Searching...'
+      try {
+        const pagefindApi = await loadPagefind(baseUrl)
+        const response = await pagefindApi.search(trimmed)
+        const data = await Promise.all(
+          response.results.slice(0, 20).map((result) => result.data()),
+        )
+        if (queryId !== activeQueryId) return
+        renderResults(
+          data.filter((item) => isPostPath(baseUrl, item.url)).slice(0, 12),
+          trimmed,
+        )
+      } catch (error) {
+        console.error('Search error:', error)
+        if (queryId === activeQueryId) {
+          summary.textContent = 'Search is unavailable.'
+        }
+      }
+    }
+
+    const updateUrl = (query: string) => {
+      const url = new URL(window.location.href)
+      if (query.trim()) {
+        url.searchParams.set('q', query.trim())
+      } else {
+        url.searchParams.delete('q')
+      }
+      window.history.replaceState({}, '', url)
+    }
+
+    const onInput = () => {
+      const value = input.value
+      updateUrl(value)
+      if (timer) window.clearTimeout(timer)
+      timer = window.setTimeout(() => search(value), 120)
+    }
+
+    input.addEventListener('input', onInput)
+
+    const params = new URLSearchParams(window.location.search)
+    const query = params.get('q')
+    if (query) {
+      input.value = query
+      search(query)
+    }
+  }
+
+  document.addEventListener('astro:page-load', initSearch)
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', applyQuery)
+    document.addEventListener('DOMContentLoaded', initSearch)
   } else {
-    applyQuery()
+    initSearch()
   }
 </script>


### PR DESCRIPTION
## Changes
- Keep Pagefind as the search backend while avoiding CJK query segmentation for short Chinese terms such as 无双.
- Use Pagefind's zh language code for the generated index and pin Pagefind to 1.5.2 via pnpm override.
- Replace the full search page with a Pagefind API-based implementation matching the nav search behavior.
- Document the Pagefind query segmentation hack in AGENTS.md and inline comments.

## Verification
- pnpm build
- Verified in Chrome that searching 无双 returns 寻找无双 in both nav search and /search.
- Verified /search/?q=寻找无双 returns 寻找无双.