### PR TITLE
fix: crop blog card cover images

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -140,7 +140,7 @@ const coverImage = getDisplayCoverImage(entry)
               alt={entry.data.title}
               width={1200}
               height={630}
-              class="bg-background/80 aspect-[1200/630] w-full rounded-lg object-contain"
+              class="bg-background/80 aspect-[1200/630] w-full rounded-lg object-cover"
             />
           </div>
         </div>


### PR DESCRIPTION
## Changes
- Crop blog card cover images to fill the fixed thumbnail frame consistently.
- Applies the same cover behavior across home, blog, tag, and author card lists.

## Verification
- pnpm build