### PR TITLE
chore: clean up startup warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 astro check && NODE_OPTIONS=--max-old-space-size=8192 astro build",
-    "preview": "astro preview",
+    "dev": "NODE_OPTIONS=--disable-warning=DEP0040 astro dev",
+    "start": "pnpm dev",
+    "build": "NODE_OPTIONS='--disable-warning=DEP0040 --max-old-space-size=8192' astro check && NODE_OPTIONS='--disable-warning=DEP0040 --max-old-space-size=8192' astro build",
+    "preview": "NODE_OPTIONS=--disable-warning=DEP0040 astro preview",
     "astro": "astro",
     "prettier": "prettier --write **/*.{ts,tsx,css,astro} --ignore-path .gitignore --ignore-path .prettierignore"
   },
@@ -52,21 +52,6 @@
     "prettier-plugin-astro-organize-imports": "^0.4.12",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "sharp": "^0.34.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "fast-xml-parser": "5.5.7",
-      "rollup": "4.59.0",
-      "h3": "1.15.9",
-      "picomatch": "4.0.4",
-      "anymatch>picomatch": "2.3.2",
-      "smol-toml": "1.6.1",
-      "yaml": "2.8.3",
-      "@iconify/tools>svgo": "3.3.3",
-      "@iconify/tools>tar": "7.5.11",
-      "cheerio>undici": "7.24.0",
-      "pagefind": "1.5.2"
-    }
   },
   "prettier": {
     "semi": false,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+packages:
+  - .
+
+overrides:
+  fast-xml-parser: 5.5.7
+  rollup: 4.59.0
+  h3: 1.15.9
+  picomatch: 4.0.4
+  anymatch>picomatch: 2.3.2
+  smol-toml: 1.6.1
+  yaml: 2.8.3
+  '@iconify/tools>svgo': 3.3.3
+  '@iconify/tools>tar': 7.5.11
+  cheerio>undici: 7.24.0
+  pagefind: 1.5.2

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { glob } from 'astro/loaders'
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
+import { z } from 'astro/zod'
 
 const blog = defineCollection({
   loader: glob({
@@ -25,14 +26,14 @@ const authors = defineCollection({
   schema: z.object({
     name: z.string(),
     pronouns: z.string().optional(),
-    avatar: z.string().url().or(z.string().startsWith('/')),
+    avatar: z.url().or(z.string().startsWith('/')),
     bio: z.string().optional(),
-    mail: z.string().email().optional(),
-    website: z.string().url().optional(),
-    twitter: z.string().url().optional(),
-    github: z.string().url().optional(),
-    linkedin: z.string().url().optional(),
-    discord: z.string().url().optional(),
+    mail: z.email().optional(),
+    website: z.url().optional(),
+    twitter: z.url().optional(),
+    github: z.url().optional(),
+    linkedin: z.url().optional(),
+    discord: z.url().optional(),
   }),
 })
 
@@ -44,7 +45,7 @@ const projects = defineCollection({
       description: z.string(),
       tags: z.array(z.string()),
       image: image(),
-      link: z.string().url(),
+      link: z.url(),
       startDate: z.coerce.date().optional(),
       endDate: z.coerce.date().optional(),
     }),

--- a/src/content/blog/2025/llm-sps/index.md
+++ b/src/content/blog/2025/llm-sps/index.md
@@ -205,7 +205,7 @@ if all_accept:
 
 - $t_{\text{target}}$: target model 一次推理 (产生一个 token) 需要的时间。论文中的 target model 为 DeepMind 的 **70B** Chinchilla 模型，推理一个 token 的耗时为 14.1ms
 - $t_{\text{draft}}$: draft model 一次推理需要的时间。论文中的 target model 为 DeepMind 的 **7B** Chinchilla 模型，推理一个 token 的耗时为 1.8ms
-- $r’$: Acceptance rate, 接受率。其计算方式为每轮推测采样 (while 循环内) 生成的 token 数量除以$K+1$.
+- $r'$: Acceptance rate, 接受率。其计算方式为每轮推测采样 (while 循环内) 生成的 token 数量除以$K+1$.
 
 因此，不采用推测采样的情况下，target model 进行自回归产生$N$个 token 的时间复杂度为$N \cdot {t_{\text{target}}}$.
 


### PR DESCRIPTION
## Changes
- Move pnpm overrides out of package.json into pnpm-workspace.yaml for pnpm 10.
- Update content schema imports and URL/email validators to the current Astro/Zod APIs.
- Fix a KaTeX warning by replacing a curly prime in math content.
- Suppress the known upstream Node DEP0040 punycode deprecation in dev/build/preview scripts only.

## Verification
- pnpm install --lockfile-only
- pnpm build
- pnpm dev --host 127.0.0.1 --port 1234