### PR TITLE
style: refine home and archive pagination

### DIFF
--- a/src/components/TagBadge.astro
+++ b/src/components/TagBadge.astro
@@ -15,7 +15,7 @@ const { tag, compact = false } = Astro.props
   href={`/tags/${tag}`}
   class={cn(
     badgeVariants({ variant: 'muted' }),
-    'text-muted-foreground hover:border-foreground/20 hover:bg-muted hover:text-foreground hover:-translate-y-0.5 cursor-pointer border-transparent bg-transparent transition-[color,background-color,border-color,transform] duration-150 ease-out',
+    'border-border/50 bg-muted/40 text-muted-foreground hover:border-foreground/20 hover:bg-muted hover:text-foreground cursor-pointer transition-colors duration-150',
     compact && 'px-1.5 py-0 text-[11px] leading-5',
   )}
 >

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,7 +7,7 @@ export const SITE: Site = {
   author: 'mathew',
   locale: 'zh-CN',
   recentPostCount: 5,
-  postsPerPage: 6,
+  postsPerPage: 10,
 }
 
 export const RSS_FOLLOW_CHALLENGE = {

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -125,7 +125,7 @@ const coverImage = getDisplayCoverImage(post)
       )
     }
 
-    <section class="col-start-2 flex flex-col gap-y-6">
+    <section class="col-start-2 flex flex-col gap-y-6 text-center">
       <div class="flex flex-col">
         <h1
           class="mb-3 scroll-mt-31 text-3xl leading-tight font-medium sm:text-4xl"
@@ -143,7 +143,7 @@ const coverImage = getDisplayCoverImage(post)
         </time>
 
         <div
-          class="text-muted-foreground mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm"
+          class="text-muted-foreground mb-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm"
         >
           {
             authors.length > 0 && (
@@ -202,7 +202,7 @@ const coverImage = getDisplayCoverImage(post)
             )
           }
         </div>
-        <div class="flex flex-wrap gap-x-3 gap-y-1">
+        <div class="flex flex-wrap justify-center gap-x-3 gap-y-1">
           {
             post.data.tags &&
               post.data.tags.length > 0 &&

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,11 +22,11 @@ const blog = await getRecentPosts(SITE.recentPostCount)
         ))
       }
     </ul>
-    <div class="flex justify-start">
+    <div class="flex justify-center">
       <Link
         href="/blog"
         class={buttonVariants({ variant: 'ghost' }) +
-          ' group text-muted-foreground px-0 hover:bg-transparent hover:text-foreground'}
+          ' group text-muted-foreground hover:bg-transparent hover:text-foreground'}
       >
         全部文章 <span
           class="ml-1.5 transition-transform group-hover:translate-x-1"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,8 +12,8 @@ const blog = await getRecentPosts(SITE.recentPostCount)
 
 <Layout class="max-w-3xl">
   <PageHead slot="head" title="首页" />
-  <section class="flex flex-col gap-y-3">
-    <ul class="flex flex-col gap-y-3">
+  <section class="flex min-h-0 grow flex-col gap-y-3">
+    <ul class="flex min-h-0 grow flex-col justify-between">
       {
         blog.map((post) => (
           <li>

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -17,6 +17,23 @@
   }
 }
 
+@keyframes footnote-item-highlight {
+  0% {
+    background-color: oklch(from var(--foreground) l c h / 0);
+    box-shadow: 0 0 0 0 oklch(from var(--foreground) l c h / 0);
+  }
+
+  25% {
+    background-color: oklch(from var(--foreground) l c h / 0.06);
+    box-shadow: 0 0 0 0.35rem oklch(from var(--foreground) l c h / 0.06);
+  }
+
+  100% {
+    background-color: oklch(from var(--foreground) l c h / 0);
+    box-shadow: 0 0 0 0 oklch(from var(--foreground) l c h / 0);
+  }
+}
+
 @layer base {
   p,
   h1,
@@ -234,7 +251,7 @@
     }
 
     :where(a[data-footnote-ref]:target):not(:where(.not-prose, .not-prose *)) {
-      animation: footnote-ref-highlight 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+      animation: footnote-ref-highlight 1.6s cubic-bezier(0.22, 1, 0.36, 1);
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -304,7 +321,22 @@
     :where(section.footnotes[data-footnotes] li):not(
       :where(.not-prose, .not-prose *)
     ) {
-      @apply text-muted-foreground scroll-mt-32 xl:scroll-mt-20;
+      @apply text-muted-foreground scroll-mt-32 rounded-sm xl:scroll-mt-20;
+    }
+
+    :where(section.footnotes[data-footnotes] li:target):not(
+      :where(.not-prose, .not-prose *)
+    ) {
+      animation: footnote-item-highlight 2s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :where(section.footnotes[data-footnotes] li:target):not(
+        :where(.not-prose, .not-prose *)
+      ) {
+        animation: none;
+        @apply bg-muted/50;
+      }
     }
 
     :where(section.footnotes[data-footnotes] a):not(


### PR DESCRIPTION
## Changes
- Increase blog archive pagination from 6 to 10 posts per page
- Keep the home page at 5 recent posts while distributing list spacing across the available viewport
- Include the recent reading interaction refinements from this branch

## Verification
- pnpm build