### PR TITLE
chore: bump pnpm packageManager to 11.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "1.6.3",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.2",
   "scripts": {
     "dev": "NODE_OPTIONS='--disable-warning=DEP0040 --max-old-space-size=8192' astro dev",
     "start": "pnpm dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - .
 
+allowBuilds:
+  esbuild: true
+  sharp: true
+
 overrides:
   fast-xml-parser: 5.5.7
   rollup: 4.59.0


### PR DESCRIPTION
## Summary
- bump the repository `packageManager` field from `pnpm@10.33.0` to `pnpm@11.5.2`
- keep the change aligned with the repo's existing Node 24 configuration in `.nvmrc` and GitHub Actions

## Validation
- local `pnpm` validation is blocked in this environment because it is running Node `22.12.0` while `pnpm@11.5.2` requires `>=22.13`
- CI runs on Node 24 and is the validation gate for this PR