### PR TITLE
feat: add inline article previews

### DIFF
--- a/src/components/ArticleLinkPreview.astro
+++ b/src/components/ArticleLinkPreview.astro
@@ -1,0 +1,596 @@
+---
+import { SITE } from '@/consts'
+import { getAllPostsAndSubposts } from '@/lib/data-utils'
+import {
+  calculateWordCountFromHtml,
+  formatDate,
+  readingTime,
+} from '@/lib/utils'
+
+const posts = await getAllPostsAndSubposts()
+const previews = Object.fromEntries(
+  posts.map((post) => [
+    `/blog/${post.id}`,
+    {
+      title: post.data.title,
+      description: post.data.description,
+      date: formatDate(post.data.date),
+      readingTime: readingTime(calculateWordCountFromHtml(post.body)),
+      tags: post.data.tags ?? [],
+    },
+  ]),
+)
+const serializedPreviews = JSON.stringify(previews).replace(/</g, '\\u003c')
+const siteHostname = new URL(SITE.href).hostname
+---
+
+<script
+  id="article-link-preview-data"
+  type="application/json"
+  is:inline
+  data-site-hostname={siteHostname}
+  set:html={serializedPreviews}
+/>
+
+<aside
+  id="article-link-preview"
+  class="border-border bg-background fixed z-60 hidden w-[min(30rem,calc(100vw-1.5rem))] rounded-lg border p-4 text-left shadow-lg"
+  aria-label="文章预览"
+  aria-hidden="true"
+>
+  <button
+    id="article-link-preview-expand"
+    type="button"
+    class="border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring absolute top-3 right-3 inline-flex size-7 items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    title="全屏阅读"
+    aria-label="全屏阅读"
+  >
+    <svg
+      class="size-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"></path>
+    </svg>
+  </button>
+
+  <div
+    id="article-link-preview-meta"
+    class="text-muted-foreground mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 pr-8 text-xs"
+  >
+    <span id="article-link-preview-date"></span>
+    <span aria-hidden="true">·</span>
+    <span id="article-link-preview-reading-time"></span>
+  </div>
+  <p
+    id="article-link-preview-title"
+    class="text-foreground mb-3 pr-8 text-base leading-snug font-medium"
+  >
+  </p>
+  <div
+    id="article-link-preview-scroll"
+    class="article-link-preview-scroll border-border/60 focus-visible:ring-ring max-h-80 overflow-y-auto overscroll-contain border-y py-3 pr-2 focus-visible:ring-2 focus-visible:outline-none"
+    tabindex="0"
+    aria-label="文章全文预览"
+  >
+    <p
+      id="article-link-preview-description"
+      class="text-muted-foreground text-sm leading-relaxed"
+    >
+    </p>
+    <div
+      id="article-link-preview-status"
+      class="text-muted-foreground mt-3 text-center text-xs"
+      role="status"
+    >
+      正在载入全文…
+    </div>
+    <div
+      id="article-link-preview-content"
+      class="article-link-preview-content prose max-w-none"
+    >
+    </div>
+  </div>
+  <div class="mt-3 flex items-end gap-3">
+    <div id="article-link-preview-tags" class="flex min-w-0 flex-wrap gap-1.5">
+    </div>
+  </div>
+</aside>
+
+<dialog
+  id="article-fullscreen-reader"
+  class="bg-background text-foreground m-0 h-dvh max-h-none w-screen max-w-none p-0"
+  aria-labelledby="article-fullscreen-title"
+>
+  <div class="flex h-full min-h-0 flex-col">
+    <header
+      class="border-border bg-background/95 sticky top-0 z-10 shrink-0 border-b backdrop-blur"
+    >
+      <div
+        class="mx-auto flex min-h-16 w-full max-w-3xl items-center justify-between gap-4 px-5 py-3 sm:px-8"
+      >
+        <div class="min-w-0">
+          <p
+            id="article-fullscreen-meta"
+            class="text-muted-foreground mb-0.5 text-xs"
+          >
+          </p>
+          <h2
+            id="article-fullscreen-title"
+            class="truncate text-base font-medium sm:text-lg"
+          >
+          </h2>
+        </div>
+        <button
+          id="article-fullscreen-close"
+          type="button"
+          class="border-border text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex size-8 shrink-0 items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          title="关闭全文"
+          aria-label="关闭全文"
+        >
+          <svg
+            class="size-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <div id="article-fullscreen-scroll" class="min-h-0 flex-1 overflow-y-auto">
+      <article class="mx-auto w-full max-w-3xl px-5 py-10 sm:px-8 sm:py-14">
+        <div
+          id="article-fullscreen-status"
+          class="text-muted-foreground py-20 text-center text-sm"
+          role="status"
+        >
+          正在载入全文…
+        </div>
+        <div id="article-fullscreen-content" class="prose max-w-none"></div>
+      </article>
+    </div>
+  </div>
+</dialog>
+
+<script>
+  type ArticlePreview = {
+    title: string
+    description: string
+    date: string
+    readingTime: string
+    tags: string[]
+  }
+
+  type PreviewWindow = Window & {
+    __articleLinkPreviewController?: AbortController
+  }
+
+  const normalizePath = (pathname: string) => {
+    const normalized = pathname.replace(/\/+$/, '')
+    return normalized || '/'
+  }
+
+  document.addEventListener('astro:page-load', () => {
+    const previewWindow = window as PreviewWindow
+    previewWindow.__articleLinkPreviewController?.abort()
+
+    const controller = new AbortController()
+    previewWindow.__articleLinkPreviewController = controller
+    const { signal } = controller
+
+    const dataElement = document.getElementById('article-link-preview-data')
+    const card = document.getElementById('article-link-preview')
+    const expandButton = document.getElementById('article-link-preview-expand')
+    const reader = document.getElementById(
+      'article-fullscreen-reader',
+    ) as HTMLDialogElement | null
+    const readerClose = document.getElementById('article-fullscreen-close')
+    const readerTitle = document.getElementById('article-fullscreen-title')
+    const readerMeta = document.getElementById('article-fullscreen-meta')
+    const readerStatus = document.getElementById('article-fullscreen-status')
+    const readerContent = document.getElementById('article-fullscreen-content')
+    const readerScroll = document.getElementById('article-fullscreen-scroll')
+    if (
+      !dataElement ||
+      !card ||
+      !expandButton ||
+      !reader ||
+      !readerClose ||
+      !readerTitle ||
+      !readerMeta ||
+      !readerStatus ||
+      !readerContent ||
+      !readerScroll
+    )
+      return
+
+    const title = document.getElementById('article-link-preview-title')
+    const description = document.getElementById(
+      'article-link-preview-description',
+    )
+    const previewScroll = document.getElementById('article-link-preview-scroll')
+    const previewStatus = document.getElementById('article-link-preview-status')
+    const previewContent = document.getElementById(
+      'article-link-preview-content',
+    )
+    const date = document.getElementById('article-link-preview-date')
+    const readTime = document.getElementById(
+      'article-link-preview-reading-time',
+    )
+    const tags = document.getElementById('article-link-preview-tags')
+    if (
+      !title ||
+      !description ||
+      !previewScroll ||
+      !previewStatus ||
+      !previewContent ||
+      !date ||
+      !readTime ||
+      !tags
+    )
+      return
+
+    const previews = JSON.parse(dataElement.textContent || '{}') as Record<
+      string,
+      ArticlePreview
+    >
+    const siteHostname = dataElement.dataset.siteHostname
+    const supportsHover = window.matchMedia(
+      '(hover: hover) and (pointer: fine)',
+    ).matches
+    let activeLink: HTMLAnchorElement | null = null
+    let openTimer: number | undefined
+    let closeTimer: number | undefined
+    let readerCloseTimer: number | undefined
+    const articleCache = new Map<string, Promise<string>>()
+
+    const clearTimers = () => {
+      window.clearTimeout(openTimer)
+      window.clearTimeout(closeTimer)
+    }
+
+    const hide = () => {
+      clearTimers()
+      activeLink?.removeAttribute('aria-describedby')
+      activeLink = null
+      card.classList.add('hidden')
+      card.setAttribute('aria-hidden', 'true')
+    }
+
+    const positionCard = (link: HTMLAnchorElement) => {
+      const gap = 10
+      const viewportPadding = 12
+      const linkRect = link.getBoundingClientRect()
+      const cardRect = card.getBoundingClientRect()
+      const left = Math.min(
+        window.innerWidth - cardRect.width - viewportPadding,
+        Math.max(
+          viewportPadding,
+          linkRect.left + linkRect.width / 2 - cardRect.width / 2,
+        ),
+      )
+      const fitsBelow =
+        linkRect.bottom + gap + cardRect.height <=
+        window.innerHeight - viewportPadding
+      const top = fitsBelow
+        ? linkRect.bottom + gap
+        : Math.max(viewportPadding, linkRect.top - cardRect.height - gap)
+
+      card.style.left = `${Math.round(left)}px`
+      card.style.top = `${Math.round(top)}px`
+    }
+
+    const show = (
+      link: HTMLAnchorElement,
+      path: string,
+      preview: ArticlePreview,
+    ) => {
+      activeLink?.removeAttribute('aria-describedby')
+      activeLink = link
+      expandButton.dataset.path = path
+      title.textContent = preview.title
+      description.textContent = preview.description
+      description.classList.remove('hidden')
+      previewStatus.textContent = '正在载入全文…'
+      previewStatus.classList.remove('hidden')
+      previewContent.replaceChildren()
+      previewScroll.scrollTop = 0
+      date.textContent = preview.date
+      readTime.textContent = preview.readingTime
+      tags.replaceChildren(
+        ...preview.tags.slice(0, 2).map((tag) => {
+          const badge = document.createElement('span')
+          badge.className =
+            'border-border/60 bg-muted/50 text-muted-foreground rounded-md border px-1.5 py-0.5 text-xs'
+          badge.textContent = tag
+          return badge
+        }),
+      )
+
+      card.classList.remove('hidden')
+      card.setAttribute('aria-hidden', 'false')
+      link.setAttribute('aria-describedby', card.id)
+      positionCard(link)
+      void loadCardArticle(path)
+    }
+
+    const getPreviewPath = (link: HTMLAnchorElement) => {
+      const url = new URL(link.href, window.location.href)
+      const isSameSite =
+        url.origin === window.location.origin || url.hostname === siteHostname
+      if (!isSameSite) return null
+
+      const path = normalizePath(url.pathname)
+      return previews[path] ? path : null
+    }
+
+    const scheduleOpen = (
+      link: HTMLAnchorElement,
+      path: string,
+      preview: ArticlePreview,
+      delay: number,
+    ) => {
+      clearTimers()
+      openTimer = window.setTimeout(() => show(link, path, preview), delay)
+    }
+
+    const scheduleClose = () => {
+      window.clearTimeout(openTimer)
+      closeTimer = window.setTimeout(hide, 240)
+    }
+
+    const closeReader = () => {
+      if (!reader.open) return
+      window.clearTimeout(readerCloseTimer)
+      reader.classList.remove('is-open')
+      readerCloseTimer = window.setTimeout(() => reader.close(), 180)
+    }
+
+    const extractArticleContent = (html: string, path: string) => {
+      const document = new DOMParser().parseFromString(html, 'text/html')
+      const article = Array.from(
+        document.querySelectorAll<HTMLElement>('article[data-url]'),
+      ).find(
+        (candidate) =>
+          normalizePath(candidate.dataset.url || '') === normalizePath(path),
+      )
+      const content = article?.querySelector<HTMLElement>('.prose')
+      if (!content) throw new Error('Article content was not found')
+
+      content
+        .querySelectorAll('script, style, iframe, object, embed, form')
+        .forEach((element) => element.remove())
+      content.querySelectorAll('[id]').forEach((element) => {
+        element.removeAttribute('id')
+      })
+      content
+        .querySelectorAll<HTMLAnchorElement>('a[href^="#"]')
+        .forEach((link) => {
+          link.removeAttribute('href')
+        })
+      return content.innerHTML
+    }
+
+    const loadArticleContent = (path: string) => {
+      const cached = articleCache.get(path)
+      if (cached) return cached
+
+      const request = fetch(path, { signal })
+        .then((response) => {
+          if (!response.ok) throw new Error(`HTTP ${response.status}`)
+          return response.text()
+        })
+        .then((html) => extractArticleContent(html, path))
+        .catch((error) => {
+          articleCache.delete(path)
+          throw error
+        })
+
+      articleCache.set(path, request)
+      return request
+    }
+
+    const loadCardArticle = async (path: string) => {
+      try {
+        const content = await loadArticleContent(path)
+        if (
+          expandButton.dataset.path !== path ||
+          card.classList.contains('hidden')
+        )
+          return
+
+        previewContent.innerHTML = content
+        description.classList.add('hidden')
+        previewStatus.classList.add('hidden')
+        previewScroll.scrollTop = 0
+        if (activeLink) positionCard(activeLink)
+      } catch (error) {
+        if (signal.aborted || expandButton.dataset.path !== path) return
+        console.error('Failed to load article card preview', error)
+        previewStatus.textContent = '全文载入失败，当前显示文章摘要。'
+      }
+    }
+
+    const openReader = async (path: string, preview: ArticlePreview) => {
+      window.clearTimeout(readerCloseTimer)
+      readerTitle.textContent = preview.title
+      readerMeta.textContent = `${preview.date} · ${preview.readingTime}`
+      readerContent.replaceChildren()
+      readerStatus.textContent = '正在载入全文…'
+      readerStatus.classList.remove('hidden')
+      readerScroll.scrollTop = 0
+
+      if (!reader.open) reader.showModal()
+      requestAnimationFrame(() => reader.classList.add('is-open'))
+
+      try {
+        const content = await loadArticleContent(path)
+        readerContent.innerHTML = content
+        readerStatus.classList.add('hidden')
+      } catch (error) {
+        if (signal.aborted) return
+        console.error('Failed to load article preview', error)
+        readerStatus.textContent = '全文载入失败，请点击原链接阅读。'
+      }
+    }
+
+    document
+      .querySelectorAll<HTMLAnchorElement>('.prose a[href]')
+      .forEach((link) => {
+        const path = getPreviewPath(link)
+        if (!path) return
+        const preview = previews[path]
+
+        link.dataset.articlePreview = 'true'
+
+        if (supportsHover) {
+          link.addEventListener(
+            'pointerenter',
+            () => scheduleOpen(link, path, preview, 120),
+            { signal },
+          )
+          link.addEventListener('pointerleave', scheduleClose, { signal })
+        }
+
+        link.addEventListener(
+          'focus',
+          () => scheduleOpen(link, path, preview, 0),
+          { signal },
+        )
+        link.addEventListener('blur', scheduleClose, { signal })
+      })
+
+    expandButton.addEventListener(
+      'click',
+      () => {
+        const path = expandButton.dataset.path
+        const preview = path ? previews[path] : undefined
+        if (!path || !preview) return
+        hide()
+        void openReader(path, preview)
+      },
+      { signal },
+    )
+
+    readerClose.addEventListener('click', closeReader, { signal })
+    reader.addEventListener(
+      'cancel',
+      (event) => {
+        event.preventDefault()
+        closeReader()
+      },
+      { signal },
+    )
+
+    if (supportsHover) {
+      card.addEventListener(
+        'pointerenter',
+        () => window.clearTimeout(closeTimer),
+        { signal },
+      )
+      card.addEventListener('pointerleave', scheduleClose, { signal })
+    }
+    card.addEventListener('focusin', () => window.clearTimeout(closeTimer), {
+      signal,
+    })
+    card.addEventListener('focusout', scheduleClose, { signal })
+
+    window.addEventListener(
+      'scroll',
+      () => {
+        if (activeLink) positionCard(activeLink)
+      },
+      { passive: true, signal },
+    )
+    window.addEventListener(
+      'resize',
+      () => {
+        if (activeLink) positionCard(activeLink)
+      },
+      { signal },
+    )
+    document.addEventListener(
+      'keydown',
+      (event) => {
+        if (event.key === 'Escape') hide()
+      },
+      { signal },
+    )
+  })
+</script>
+
+<style>
+  #article-link-preview {
+    animation: article-link-preview-in 100ms ease-out;
+  }
+
+  .article-link-preview-scroll {
+    scrollbar-gutter: stable;
+    scrollbar-color: var(--border) transparent;
+    scrollbar-width: thin;
+  }
+
+  .article-link-preview-scroll::-webkit-scrollbar {
+    width: 5px;
+  }
+
+  .article-link-preview-scroll::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 999px;
+  }
+
+  #article-fullscreen-reader {
+    opacity: 0;
+    transform: scale(0.992);
+    transition:
+      opacity 180ms ease-out,
+      transform 180ms ease-out;
+  }
+
+  #article-fullscreen-reader.is-open {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  #article-fullscreen-reader::backdrop {
+    background: color-mix(in oklch, var(--foreground) 16%, transparent);
+    opacity: 0;
+    transition: opacity 180ms ease-out;
+  }
+
+  #article-fullscreen-reader.is-open::backdrop {
+    opacity: 1;
+  }
+
+  @keyframes article-link-preview-in {
+    from {
+      opacity: 0;
+      transform: translateY(2px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #article-link-preview,
+    #article-fullscreen-reader,
+    #article-fullscreen-reader::backdrop {
+      animation: none;
+      transition: none;
+    }
+  }
+</style>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,5 +1,6 @@
 ---
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
+import ArticleLinkPreview from '@/components/ArticleLinkPreview.astro'
 import Giscus from '@/components/Giscus.astro'
 import Icon from '@/components/Icon.astro'
 import Link from '@/components/Link.astro'
@@ -287,6 +288,8 @@ const hasToc = tocSections.length > 0
   </section>
 
   {chain.length > 1 && <SeriesReader />}
+
+  <ArticleLinkPreview />
 
   <button
     class={buttonVariants({


### PR DESCRIPTION
## Changes
- preview internal blog articles on hover and keyboard focus
- load the full article into a scrollable preview card
- support animated full-screen reading from the preview
- preserve mobile link behavior and cache fetched article content

## Validation
- pnpm build
- browser-tested on /blog/2026/wang-xiaobo/