### PR TITLE
fix: align header logo with site title

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,12 +12,14 @@ import logo from '../../public/static/logo.svg'
   <div
     class="mx-auto flex max-w-3xl items-center justify-between gap-4 px-4 py-3"
   >
-    <Link href="/" class="flex shrink-0 items-center justify-center gap-3">
-      <Image src={logo} alt="Logo" class="size-5 sm:size-6" />
-      <span
-        class="hidden h-full text-lg leading-none font-medium min-[400px]:block"
-        >{SITE.title}</span
-      >
+    <Link href="/" class="shrink-0">
+      <span class="flex items-center justify-center gap-3">
+        <Image src={logo} alt="Logo" class="size-5 sm:size-6" />
+        <span
+          class="hidden h-full text-lg leading-none font-medium min-[400px]:block"
+          >{SITE.title}</span
+        >
+      </span>
     </Link>
     <div class="flex items-center gap-4">
       <nav class="flex items-center gap-4 text-sm sm:gap-6">


### PR DESCRIPTION
## Changes

- Keep the shared link component unchanged.
- Wrap the header brand contents in a dedicated flex container.
- Render the logo to the left of the site title.

## Root cause

The shared `Link` component applies `inline-block`, which won the generated CSS display rule over the header's `flex` class and caused the logo and title to stack vertically.

## Impact

The header branding now uses the intended horizontal layout without changing link behavior elsewhere.

## Validation

- `pnpm build`
- Astro check: 0 errors, 0 warnings, 0 hints
- Static build: 72 pages generated
