### PR TITLE
fix: refine header brand alignment

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,8 +13,8 @@ import logo from '../../public/static/logo.svg'
     class="mx-auto flex max-w-3xl items-center justify-between gap-4 px-4 py-3"
   >
     <Link href="/" class="shrink-0">
-      <span class="flex items-center justify-center gap-3">
-        <Image src={logo} alt="Logo" class="size-5 sm:size-6" />
+      <span class="flex items-center justify-center gap-2">
+        <Image src={logo} alt="Logo" class="size-5 -translate-y-px sm:size-6" />
         <span
           class="hidden h-full text-lg leading-none font-medium min-[400px]:block"
           >{SITE.title}</span


### PR DESCRIPTION
## Changes

- Shift the header logo upward by 1px for optical vertical alignment.
- Reduce the logo/title element gap from 12px to 8px.

## Why

The SVG artwork sits slightly low within its square viewBox and includes internal whitespace on its right edge. Geometric centering and a 12px element gap therefore appeared vertically offset and visually too loose.

## Impact

The header logo and site title now appear more balanced without changing the shared logo asset or link behavior elsewhere.

## Validation

- `pnpm build`
- Astro check: 0 errors, 0 warnings, 0 hints
- Static build: 72 pages generated
